### PR TITLE
방 로직 개선

### DIFF
--- a/src/main/java/com/chatting/capstone/domain/room/controller/RoomController.java
+++ b/src/main/java/com/chatting/capstone/domain/room/controller/RoomController.java
@@ -4,7 +4,6 @@ import com.chatting.capstone.domain.room.dto.response.RoomResponse;
 import com.chatting.capstone.domain.room.service.RoomService;
 import com.chatting.capstone.domain.user.dto.request.UserRequest;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,13 +29,15 @@ public class RoomController {
 
     // 방 입장
     @PostMapping("/{roomId}/join")
-    public ResponseEntity<Map<String, Object>> joinRoom(@PathVariable Long roomId, @RequestBody UserRequest request) {
-        return roomService.joinRoom(roomId, request.getUserId());
+    public ResponseEntity<String> joinRoom(@PathVariable Long roomId, @RequestBody UserRequest request) {
+        roomService.joinRoomById(request.getUserId(), roomId);
+        return ResponseEntity.ok( "방에 성공적으로 입장했습니다.");
     }
 
     // 방 퇴장
     @PostMapping("/{roomId}/leave")
-    public ResponseEntity<Map<String, Object>> leaveRoom(@PathVariable Long roomId, @RequestBody UserRequest request) {
-        return roomService.leaveRoom(roomId, request.getUserId());
+    public ResponseEntity<String> leaveRoom(@PathVariable Long roomId, @RequestBody UserRequest request) {
+       roomService.leaveRoom(roomId, request.getUserId());
+        return ResponseEntity.ok("방에서 성공적으로 퇴장했습니다.");
     }
 }

--- a/src/main/java/com/chatting/capstone/domain/room/dto/request/RoomRequest.java
+++ b/src/main/java/com/chatting/capstone/domain/room/dto/request/RoomRequest.java
@@ -1,0 +1,10 @@
+package com.chatting.capstone.domain.room.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RoomRequest {
+    private Long roomId; // 방 ID
+}

--- a/src/main/java/com/chatting/capstone/domain/room/service/RoomService.java
+++ b/src/main/java/com/chatting/capstone/domain/room/service/RoomService.java
@@ -8,10 +8,12 @@ import com.chatting.capstone.domain.user.entity.User;
 import com.chatting.capstone.domain.user.repository.UserRepository;
 import com.chatting.capstone.global.exception.GlobalExceptionHandler;
 import com.chatting.capstone.global.exception.ResponseStatus;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -39,29 +41,27 @@ public class RoomService {
     }
 
     // 방 입장
-    public ResponseEntity<Map<String, Object>> joinRoom(Long roomId, Long userId) {
-        Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        ResponseStatus.ROOM_NOT_FOUND.getStatus(),
-                        ResponseStatus.ROOM_NOT_FOUND.name()
-                ));
+    @Transactional
+    public void joinRoomById(Long userId, Long roomId) {
 
+        // 1. 사용자 조회
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        ResponseStatus.USER_NOT_FOUND.getStatus(),
-                        ResponseStatus.USER_NOT_FOUND.name()
-                ));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다. ID: " + userId));
 
+        // 2. 입장할 방 조회
+        Room targetRoom = roomRepository.findById(roomId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "입장하려는 방을 찾을 수 없습니다. ID: " + roomId));
+
+        // 3. 이미 해당 방에 있는지 확인
         if (user.getRoom() != null && user.getRoom().getId().equals(roomId)) {
-            throw new ResponseStatusException(
-                    ResponseStatus.ALREADY_IN_ROOM.getStatus(),
-                    ResponseStatus.ALREADY_IN_ROOM.name()
-            );
+            throw new ResponseStatusException(HttpStatus.CONFLICT, // 409 Conflict
+                    "이미 해당 방(" + targetRoom.getRoomName() + ")에 참여 중입니다.");
         }
 
-        user.setRoom(room);
-        userRepository.save(user);
-        return GlobalExceptionHandler.buildSuccessResponse(ResponseStatus.ROOM_JOIN_SUCCESS);
+        // 4. 사용자에게 방 정보 설정
+        user.setRoom(targetRoom);
+        userRepository.save(user); // 변경된 사용자 정보 저장
     }
 
     // 방 퇴장

--- a/src/main/java/com/chatting/capstone/domain/user/controller/UserController.java
+++ b/src/main/java/com/chatting/capstone/domain/user/controller/UserController.java
@@ -35,6 +35,7 @@ public class UserController {
         return ResponseEntity.ok("로그인에 성공했습니다.");
     }
 
+    // 로그아웃
     @PostMapping("/logout")
     public ResponseEntity<String> logout(HttpSession session) {
         User user = (User) session.getAttribute("user");
@@ -48,6 +49,7 @@ public class UserController {
         }
     }
 
+    // 중복 닉네임 체크
     @GetMapping("/check-nickname")
     public ResponseEntity<String> checkNickname(@RequestParam String nickname) {
         userService.isNicknameTaken(nickname);

--- a/src/main/java/com/chatting/capstone/domain/user/controller/UserController.java
+++ b/src/main/java/com/chatting/capstone/domain/user/controller/UserController.java
@@ -7,7 +7,6 @@ import com.chatting.capstone.global.util.IpUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,20 +22,17 @@ public class UserController {
 
     private final UserService userService;
 
+    // 로그인
     @PostMapping("/login")
     public ResponseEntity<String> login(@RequestBody LoginRequest loginRequest,
             HttpSession session,
             HttpServletRequest request) {
         String nickname = loginRequest.getNickname();
         String ipAddress = IpUtil.getClientIP(request);
+        User user = userService.loginOrCreate(nickname, ipAddress);
 
-        try {
-            User user = userService.loginOrCreate(nickname, ipAddress); // IP 전달
-            session.setAttribute("user", user);
-            return ResponseEntity.ok("로그인에 성공했습니다.");
-        } catch (RuntimeException e) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
-        }
+        session.setAttribute("user", user); // 세션에 사용자 정보 저장
+        return ResponseEntity.ok("로그인에 성공했습니다.");
     }
 
     @PostMapping("/logout")
@@ -54,10 +50,7 @@ public class UserController {
 
     @GetMapping("/check-nickname")
     public ResponseEntity<String> checkNickname(@RequestParam String nickname) {
-        if (userService.isNicknameTaken(nickname)) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body("사용중인 닉네임입니다.");
-        } else {
-            return ResponseEntity.ok("사용 가능한 닉네임입니다.");
-        }
+        userService.isNicknameTaken(nickname);
+        return ResponseEntity.ok("사용 가능한 닉네임입니다.");
     }
 }

--- a/src/main/java/com/chatting/capstone/domain/user/entity/User.java
+++ b/src/main/java/com/chatting/capstone/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.chatting.capstone.domain.user.entity;
 import com.chatting.capstone.domain.room.entity.Room;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -36,8 +37,8 @@ public class User {
     @Column(nullable = false)
     private boolean active = true;
 
-    @ManyToOne(optional = false)  // 필수 값으로 설정
-    @JoinColumn(name = "room_id", nullable = false)  // DB와 동기화
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = true )  // DB와 동기화
     private Room room;
 
 }

--- a/src/main/java/com/chatting/capstone/domain/user/service/UserService.java
+++ b/src/main/java/com/chatting/capstone/domain/user/service/UserService.java
@@ -1,13 +1,10 @@
 package com.chatting.capstone.domain.user.service;
 
-import com.chatting.capstone.domain.room.entity.Room;
-import com.chatting.capstone.domain.room.repository.RoomRepository;
+import com.chatting.capstone.global.exception.ResponseStatus;
+import org.springframework.http.HttpStatus;
 import com.chatting.capstone.domain.user.entity.User;
 import com.chatting.capstone.domain.user.repository.UserRepository;
-import com.chatting.capstone.global.exception.ResponseStatus;
 import jakarta.transaction.Transactional;
-import java.util.List;
-import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -16,54 +13,38 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final RoomRepository roomRepository;
     private final UserRepository userRepository;
-
-    // 닉네임 중복 확인
-    public boolean isNicknameTaken(String nickname) {
-        return userRepository.existsByNickname(nickname);
-    }
 
     // 로그인
     @Transactional
     public User loginOrCreate(String nickname, String ipAddress) {
-        Room randomRoom = getRandomRoom(); // 방 먼저 선택
-
-        return userRepository.findByNickname(nickname)
-                .map(user -> {
-                    if (user.isActive()) {
-                        throw new RuntimeException("이미 로그인 중인 닉네임입니다.");
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임을 입력해주세요.");
+        }
+        User user = userRepository.findByNickname(nickname)
+                .map(existingUser -> { // 기존 사용자
+                    if (existingUser.isActive()) {
+                        throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 로그인 중인 닉네임입니다.");
                     }
-                    user.setActive(true);
-                    user.setIpAddress(ipAddress);
-                    user.setRoom(randomRoom); // 방 재할당
-                    return userRepository.save(user);
+                    existingUser.setActive(true);
+                    existingUser.setIpAddress(ipAddress);
+                    existingUser.setRoom(null); // 방 정보는 여기서 설정 안 함
+                    return userRepository.save(existingUser);
                 })
-                .orElseGet(() -> {
+                .orElseGet(() -> { // 새 사용자
                     User newUser = User.builder()
                             .nickname(nickname)
                             .ipAddress(ipAddress)
                             .active(true)
-                            .room(randomRoom)
+                            .room(null) // 초기 방 설정 안 함
                             .build();
                     return userRepository.save(newUser);
                 });
-    }
-
-    // 방 랜덤 선택
-    private Room getRandomRoom() {
-        List<Room> rooms = roomRepository.findAll();
-
-        if (rooms.isEmpty()) {
-            throw new ResponseStatusException(ResponseStatus.ROOM_NOT_FOUND.getStatus(),
-                    ResponseStatus.ROOM_NOT_FOUND.name());
-        }
-
-        Random random = new Random();
-        return rooms.get(random.nextInt(rooms.size()));
+        return user;
     }
 
     // 로그아웃
+    @Transactional
     public void logout(User user) {
         if (user == null) {
             throw new ResponseStatusException(ResponseStatus.USER_NOT_FOUND.getStatus(),
@@ -73,5 +54,13 @@ public class UserService {
         user.setActive(false);
         user.setRoom(null); // 방에서 퇴장
         userRepository.save(user);
+    }
+
+    // 닉네임 중복 확인
+    public void isNicknameTaken(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "사용중인 닉네임입니다.");
+        }
+        userRepository.existsByNickname(nickname);
     }
 }

--- a/src/main/java/com/chatting/capstone/global/config/RoomInitializer.java
+++ b/src/main/java/com/chatting/capstone/global/config/RoomInitializer.java
@@ -3,7 +3,6 @@ package com.chatting.capstone.global.config;
 import com.chatting.capstone.domain.room.entity.Room;
 import com.chatting.capstone.domain.room.repository.RoomRepository;
 import jakarta.transaction.Transactional;
-import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
@@ -16,9 +15,15 @@ public class RoomInitializer implements CommandLineRunner {
     @Override
     @Transactional
     public void run(String... args) {
+        // 메인 방
         createRoomIfNotExists("Room 1");
         createRoomIfNotExists("Room 2");
         createRoomIfNotExists("Room 3");
+
+        // 통로 방
+        createRoomIfNotExists("Bridge 1");
+        createRoomIfNotExists("Bridge 2");
+        createRoomIfNotExists("Bridge 3");
     }
 
     private void createRoomIfNotExists(String roomName) {
@@ -26,7 +31,6 @@ public class RoomInitializer implements CommandLineRunner {
             roomRepository.save(
                     Room.builder()
                             .roomName(roomName)
-                            .users(new ArrayList<>())
                             .build()
             );
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
         jdbc:
           time_zone: Asia/Seoul         # DB 시간대 강제 지정
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     generate-ddl: false
   sql:
     init:


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#25 

### 📝 작업 내용
- [x] 방 자동 배정 방식을 직접 배정으로 변경합니다.
- [x] Controller의 불필요한 try-catch를 Service로 옮깁니다.
- [x] 로그인 후 직접 방 배정을 하기 위해, RoomId의 nullable 허용 및 지연 로딩을 적용합니다.
- [x] 방 구조를 3개 -> 6개(메인 3개, 통로 3개)로 확장합니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)
엔티티 변경사항 반영을 위해서 ddl-auto를 create로 지정했습니다.
필요 시, update로 변경하셔도 됩니다!