### PR TITLE
Redis를 이용한 좌표 저장 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis' // Redis
 }
 
 tasks.named('test') {

--- a/src/main/java/com/chatting/capstone/domain/location/controller/CoordinateController.java
+++ b/src/main/java/com/chatting/capstone/domain/location/controller/CoordinateController.java
@@ -1,0 +1,31 @@
+package com.chatting.capstone.domain.location.controller;
+
+import com.chatting.capstone.domain.location.service.UserLocationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coordinates")
+public class CoordinateController {
+
+    private final UserLocationService userLocationService;
+
+    // 특정 사용자의 현재 좌표 정보(방 이름 포함) 조회
+    @GetMapping("/{userId}")
+    public ResponseEntity<Map<String, String>> getUserCoordinate(@PathVariable  String userId) {
+        Map<String, String> location = userLocationService.getUserLocation(userId);
+
+        if (location.isEmpty()) {
+            // Redis에 사용자 위치 정보가 없으면 404 반환
+            return ResponseEntity.notFound().build();
+        } else {
+            // 정보가 있으면 200 OK 와 함께 Map 데이터 반환
+            return ResponseEntity.ok(location);
+        }
+    }
+
+    // POST, PATCH, GET (all users) 엔드포인트는 구현 필요, WebSocket에서 처리
+}

--- a/src/main/java/com/chatting/capstone/domain/location/entity/Portal.java
+++ b/src/main/java/com/chatting/capstone/domain/location/entity/Portal.java
@@ -1,0 +1,33 @@
+package com.chatting.capstone.domain.location.entity;
+
+import com.chatting.capstone.domain.room.entity.Room;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Portal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 포탈 고유 ID
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) // Portal은 반드시 Room에 속해야 함
+    @JoinColumn(name = "room_id", nullable = false) // 외래 키 컬럼 지정
+    private Room room;
+
+    // 기존 필드들
+    private int portalX;
+    private int portalY;
+    private String targetRoomName;
+    private int targetX;
+    private int targetY;
+}

--- a/src/main/java/com/chatting/capstone/domain/location/service/MovementService.java
+++ b/src/main/java/com/chatting/capstone/domain/location/service/MovementService.java
@@ -1,0 +1,90 @@
+package com.chatting.capstone.domain.location.service;
+
+import com.chatting.capstone.domain.room.entity.Room;
+import com.chatting.capstone.domain.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate; // WebSocket 브로드캐스트용
+import org.springframework.stereotype.Service;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MovementService {
+
+    private final UserLocationService userLocationService; // Redis 서비스
+    private final RoomRepository roomRepository;          // DB Room 정보
+    private final SimpMessagingTemplate messagingTemplate;
+
+    // WASD 이동 요청 처리 (좌표 제한 포함)
+    public void handleMovement(String userId, String key) {
+        // 1. Redis에서 현재 위치 정보 가져오기
+        Map<String, String> location = userLocationService.getUserLocation(userId);
+        if (location.isEmpty()) {
+            return; // 위치 정보 없으면 이동 불가
+        }
+
+        String currentRoomName = location.get("roomName");
+        int currentX = 0;
+        int currentY = 0;
+        try {
+            currentX = Integer.parseInt(location.getOrDefault("x", "0"));
+            currentY = Integer.parseInt(location.getOrDefault("y", "0"));
+        } catch (NumberFormatException e) {
+            return; // 좌표 파싱 실패 시 이동 불가
+        }
+
+        // 2. 현재 방 정보 가져오기 (DB 조회 - 캐싱 고려)
+        Optional<Room> roomOpt = roomRepository.findByRoomName(currentRoomName);
+        if (roomOpt.isEmpty()) {
+            // 필요 시 사용자에게 오류 알림 로직 추가
+            return; // 방 정보 없으면 이동 불가
+        }
+        Room currentRoom = roomOpt.get();
+
+        // 3. 새 좌표 계산
+        int newX = currentX;
+        int newY = currentY;
+
+        switch (key.toUpperCase()) {
+            case "W":
+                // 좌표 제한 로직: 0 이상
+                newY = Math.max(0, currentY - 1);
+                break;
+            case "A":
+                // 좌표 제한 로직: 0 이상
+                newX = Math.max(0, currentX - 1);
+                break;
+            case "S":
+                // 좌표 제한 로직: 방 높이(height) - 1 이하
+                newY = Math.min(currentRoom.getHeight() - 1, currentY + 1);
+                break;
+            case "D":
+                // 좌표 제한 로직: 방 너비(width) - 1 이하
+                newX = Math.min(currentRoom.getWidth() - 1, currentX + 1);
+                break;
+            default:
+                return; // WASD 아니면 무시
+        }
+
+        // 4. 좌표가 실제로 변경되었는지 확인
+        if (newX != currentX || newY != currentY) {
+            // 4.1 Redis 업데이트
+            userLocationService.setUserLocation(userId, currentRoomName, newX, newY);
+
+            // 4.2 같은 방 사용자들에게 이동 결과 브로드캐스트 (다음 이슈에서 구현)
+            /*
+            String destination = "/topic/room/" + currentRoomName + "/move";
+            Map<String, Object> payload = Map.of(
+                "type", "MOVE",
+                "userId", userId,
+                "x", newX,
+                "y", newY
+            );
+            messagingTemplate.convertAndSend(destination, payload);
+            */
+        }
+    }
+
+    // handleInteraction 메소드는 다른 이슈에서 구현
+}

--- a/src/main/java/com/chatting/capstone/domain/location/service/UserLocationService.java
+++ b/src/main/java/com/chatting/capstone/domain/location/service/UserLocationService.java
@@ -1,0 +1,53 @@
+package com.chatting.capstone.domain.location.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserLocationService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // Redis Key Prefix (사용자 ID 기반)
+    private static final String USER_LOCATION_KEY_PREFIX = "user:location:";
+
+    // Hash 필드 이름
+    private static final String FIELD_ROOM_NAME = "roomName";
+    private static final String FIELD_X = "x";
+    private static final String FIELD_Y = "y";
+
+    // 사용자의 위치 정보를 Redis Hash에 저장/업데이트
+    public void setUserLocation(String userId, String roomName, int x, int y) {
+        String key = USER_LOCATION_KEY_PREFIX + userId;
+        HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
+        hashOps.put(key, FIELD_ROOM_NAME, roomName);
+        hashOps.put(key, FIELD_X, String.valueOf(x));
+        hashOps.put(key, FIELD_Y, String.valueOf(y));
+         redisTemplate.expire(key, 1, TimeUnit.HOURS); // 1시간 후 자동 삭제
+    }
+
+    // 특정 사용자의 전체 위치 정보(Map)를 Redis에서 가져옴
+    public Map<String, String> getUserLocation(String userId) {
+        String key = USER_LOCATION_KEY_PREFIX + userId;
+        HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
+        return hashOps.entries(key);
+    }
+
+    // 특정 사용자의 현재 방 이름만 가져옴
+    public Optional<String> getCurrentRoomName(String userId) {
+        String key = USER_LOCATION_KEY_PREFIX + userId;
+        HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
+        return Optional.ofNullable(hashOps.get(key, FIELD_ROOM_NAME));
+    }
+
+    // 특정 사용자의 위치 정보를 Redis에서 삭제 (로그아웃, 연결 종료 시)
+    public void deleteUserLocation(String userId) {
+        String key = USER_LOCATION_KEY_PREFIX + userId;
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/chatting/capstone/domain/room/entity/Room.java
+++ b/src/main/java/com/chatting/capstone/domain/room/entity/Room.java
@@ -1,19 +1,15 @@
 package com.chatting.capstone.domain.room.entity;
 
+import com.chatting.capstone.domain.location.entity.Portal;
 import com.chatting.capstone.domain.user.entity.User;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-
-import jakarta.persistence.OneToMany;
-import java.util.List;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -26,10 +22,36 @@ public class Room {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 방 ID
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String roomName; // 방 이름
 
-    @OneToMany(mappedBy = "room")
-    private List<User> users;  // 방에 속한 사용자 목록
+    // 좌표 제한 및 포탈 위한 필드
+    @Column(nullable = false)
+    @Builder.Default
+    private int width = 1600; // 방 가로 크기 (1600)
 
+    @Column(nullable = false)
+    @Builder.Default
+    private int height = 900; // 방 세로 크기 (900)
+
+    @OneToMany(mappedBy = "room", // Portal 엔티티의 'room' 필드에 의해 매핑됨
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL, // Room 저장/삭제 시 Portal도 함께 처리
+            orphanRemoval = true)      // Room의 portals 리스트에서 제거되면 DB에서도 삭제
+    @Builder.Default
+    private List<Portal> portals = new ArrayList<>();
+
+    @OneToMany(mappedBy = "room")
+    private List<User> users = new ArrayList<>();
+
+    // --- 중요: 연관관계 편의 메소드 (양방향 설정) ---
+    public void addPortal(Portal portal) {
+        this.portals.add(portal);
+        portal.setRoom(this); // Portal 객체에도 Room 참조 설정
+    }
+
+    public void removePortal(Portal portal) {
+        this.portals.remove(portal);
+        portal.setRoom(null); // 참조 제거 (orphanRemoval=true 설정 시 DB에서도 삭제됨)
+    }
 }

--- a/src/main/java/com/chatting/capstone/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/chatting/capstone/domain/room/repository/RoomRepository.java
@@ -1,8 +1,10 @@
 package com.chatting.capstone.domain.room.repository;
+import java.util.Optional;
 
 import com.chatting.capstone.domain.room.entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
     boolean existsByRoomName(String roomName);
+    Optional<Room> findByRoomName(String roomName);
 }

--- a/src/main/java/com/chatting/capstone/domain/room/service/RoomService.java
+++ b/src/main/java/com/chatting/capstone/domain/room/service/RoomService.java
@@ -1,20 +1,18 @@
 package com.chatting.capstone.domain.room.service;
 
+import com.chatting.capstone.domain.location.service.UserLocationService;
 import com.chatting.capstone.domain.room.dto.response.RoomResponse;
 import com.chatting.capstone.domain.room.entity.Room;
 import com.chatting.capstone.domain.room.repository.RoomRepository;
 import com.chatting.capstone.domain.user.dto.response.UserResponse;
 import com.chatting.capstone.domain.user.entity.User;
 import com.chatting.capstone.domain.user.repository.UserRepository;
-import com.chatting.capstone.global.exception.GlobalExceptionHandler;
 import com.chatting.capstone.global.exception.ResponseStatus;
 import jakarta.transaction.Transactional;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -24,6 +22,7 @@ public class RoomService {
 
     private final RoomRepository roomRepository;
     private final UserRepository userRepository;
+    private final UserLocationService userLocationService;
 
     // 방 목록 조회
     public List<RoomResponse> getAllRooms() {
@@ -62,38 +61,47 @@ public class RoomService {
         // 4. 사용자에게 방 정보 설정
         user.setRoom(targetRoom);
         userRepository.save(user); // 변경된 사용자 정보 저장
+
+        // 5. 방의 중앙 좌표 계산
+        int centerX = targetRoom.getWidth() / 2;  // 1600 / 2 = 800
+        int centerY = targetRoom.getHeight() / 2; // 900 / 2 = 450
+
+        // 7. Redis에 초기 위치 정보 저장/갱신
+        // userId를 String으로 변환하여 사용 (UserLocationService 스펙에 맞춤)
+        userLocationService.setUserLocation(String.valueOf(userId), targetRoom.getRoomName(), centerX, centerY);
     }
 
     // 방 퇴장
-    public ResponseEntity<Map<String, Object>> leaveRoom(Long roomId, Long userId) {
-        // 방 찾기
+    @Transactional
+    public void  leaveRoom(Long roomId, Long userId) {
+        // 1. 방 찾기
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new ResponseStatusException(
                         ResponseStatus.ROOM_NOT_FOUND.getStatus(),
                         ResponseStatus.ROOM_NOT_FOUND.name()
                 ));
 
-        // 유저 찾기
+        // 2. 유저 찾기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(
                         ResponseStatus.USER_NOT_FOUND.getStatus(),
                         ResponseStatus.USER_NOT_FOUND.name()
                 ));
 
-        // 유저가 해당 방에 속해 있는지 확인
+        // 3. 유저가 현재 방에 속해 있는지 확인
         if (user.getRoom() == null || !user.getRoom().getId().equals(room.getId())) {
-            // 예외 처리
             throw new ResponseStatusException(
                     ResponseStatus.USER_NOT_IN_ROOM.getStatus(),
                     ResponseStatus.USER_NOT_IN_ROOM.name()
             );
         }
 
-        // 유저 방에서 퇴장
+        // 4. 유저 방 정보 DB에서 제거
         user.setRoom(null);
         userRepository.save(user);
 
-        // 퇴장 완료 메시지
-        return GlobalExceptionHandler.buildSuccessResponse(ResponseStatus.ROOM_LEAVE_SUCCESS);
+        // 5. Redis에서 사용자 위치 정보 삭제
+        // userId를 String으로 변환하여 전달 (UserLocationService 스펙 확인)
+        userLocationService.deleteUserLocation(String.valueOf(userId));
     }
 }

--- a/src/main/java/com/chatting/capstone/global/config/RedisConfig.java
+++ b/src/main/java/com/chatting/capstone/global/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package com.chatting.capstone.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        // Key Serializer 설정 (String)
+        template.setKeySerializer(new StringRedisSerializer());
+        // Value Serializer 설정 (String) - 일반적인 값
+        template.setValueSerializer(new StringRedisSerializer());
+        // Hash Key Serializer 설정 (String)
+        template.setHashKeySerializer(new StringRedisSerializer());
+        // Hash Value Serializer 설정 (String)
+        template.setHashValueSerializer(new StringRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
     hibernate:
       ddl-auto: create
     generate-ddl: false
+  data:
+    redis:
+      host: localhost #Local: localhost, Docker: redis
+      port: 6379 # Docker에서 Redis 컨테이너가 6379 포트를 사용하므로, 호스트에서도 동일한 포트를 사용
+      password:
   sql:
     init:
       mode: never


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#28 

### 📝 작업 내용
- Redis를 이용한 좌표 저장 로직을 구현합니다.
- 방에 입장했을 때, 초기 위치는 x: 800, y: 450으로 중앙에 위치하도록 구현했습니다.
- 방의 전체 크기는 1600*900으로 지정했고 변경될 수 있습니다.
- Redis는 Hash 형태로 저장합니다.
- 특정 유저 좌표 조회 api 구현했습니다.

### 📷 스크린샷 (선택)
![asdf](https://github.com/user-attachments/assets/84618079-258d-4729-bdc3-f01e063bd3ba)

### 💬 리뷰 요구사항 (선택)
테스트를 위해 로컬 환경에서 Redis 설치가 필요합니다.
