### PR TITLE
feat/#37-customization 에셋 저장, 전송 구현

### DIFF
--- a/src/main/java/com/chatting/capstone/domain/customization/controller/CustomizationController.java
+++ b/src/main/java/com/chatting/capstone/domain/customization/controller/CustomizationController.java
@@ -1,0 +1,24 @@
+package com.chatting.capstone.domain.customization.controller;
+
+import com.chatting.capstone.domain.customization.dto.request.CustomizationRequest;
+import com.chatting.capstone.domain.customization.service.CustomizationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/customization")
+public class CustomizationController {
+
+    private final CustomizationService customizationService;
+
+    public CustomizationController(CustomizationService service) {
+        this.customizationService = service;
+    }
+
+    @PostMapping("/update")
+    public ResponseEntity<?> updateCustomization(@RequestBody CustomizationRequest request) {
+        customizationService.updateCustomization(request);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/chatting/capstone/domain/customization/dto/request/CustomizationRequest.java
+++ b/src/main/java/com/chatting/capstone/domain/customization/dto/request/CustomizationRequest.java
@@ -1,0 +1,12 @@
+package com.chatting.capstone.domain.customization.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CustomizationRequest {
+    private String nickname;
+    private int hairType;
+    private int outfitType;
+}

--- a/src/main/java/com/chatting/capstone/domain/customization/dto/response/CustomizationResponse.java
+++ b/src/main/java/com/chatting/capstone/domain/customization/dto/response/CustomizationResponse.java
@@ -1,0 +1,12 @@
+package com.chatting.capstone.domain.customization.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomizationResponse {
+    private Long userId;
+    private int hairType;
+    private int outfitType;
+}

--- a/src/main/java/com/chatting/capstone/domain/customization/entity/Customization.java
+++ b/src/main/java/com/chatting/capstone/domain/customization/entity/Customization.java
@@ -1,0 +1,25 @@
+package com.chatting.capstone.domain.customization.entity;
+
+import com.chatting.capstone.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Entity
+@Getter
+@Setter
+public class Customization {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private int hairType;
+    private int outfitType;
+
+}

--- a/src/main/java/com/chatting/capstone/domain/customization/repository/CustomizationRepository.java
+++ b/src/main/java/com/chatting/capstone/domain/customization/repository/CustomizationRepository.java
@@ -1,0 +1,11 @@
+package com.chatting.capstone.domain.customization.repository;
+
+import com.chatting.capstone.domain.customization.entity.Customization;
+import com.chatting.capstone.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface CustomizationRepository extends JpaRepository<Customization, Long> {
+    Optional<Customization> findByUser(User user);
+}

--- a/src/main/java/com/chatting/capstone/domain/customization/service/CustomizationService.java
+++ b/src/main/java/com/chatting/capstone/domain/customization/service/CustomizationService.java
@@ -1,0 +1,52 @@
+package com.chatting.capstone.domain.customization.service;
+
+import com.chatting.capstone.domain.customization.dto.request.CustomizationRequest;
+import com.chatting.capstone.domain.customization.dto.response.CustomizationResponse;
+import com.chatting.capstone.domain.customization.entity.Customization;
+import com.chatting.capstone.domain.customization.repository.CustomizationRepository;
+import com.chatting.capstone.domain.user.entity.User;
+import com.chatting.capstone.domain.user.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CustomizationService {
+
+    private final CustomizationRepository customizationRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final UserRepository userRepository;
+
+
+    public void updateCustomization(CustomizationRequest customizationRequest) {
+        Optional<User> userOptional = userRepository.findByNickname(customizationRequest.getNickname());
+        if (userOptional.isEmpty()) throw new RuntimeException("사용자 없음");
+
+        User user = userOptional.get();
+
+        Customization customization = customizationRepository.findByUser(user)
+            .orElse(new Customization());
+
+        customization.setUser(user);
+        customization.setHairType(customizationRequest.getHairType());
+        customization.setOutfitType(customizationRequest.getOutfitType());
+
+        customizationRepository.save(customization);
+
+        // WebSocket 브로드캐스트
+        CustomizationResponse response = new CustomizationResponse(
+            user.getId(),
+            customization.getHairType(),
+            customization.getOutfitType()
+        );
+        System.out.println("Broadcasting customization update: " + response);
+        messagingTemplate.convertAndSend("/topic/customization", response);
+    }
+
+}

--- a/src/main/java/com/chatting/capstone/domain/user/entity/User.java
+++ b/src/main/java/com/chatting/capstone/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.chatting.capstone.domain.user.entity;
 
+import com.chatting.capstone.domain.customization.entity.Customization;
 import com.chatting.capstone.domain.room.entity.Room;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,4 +44,6 @@ public class User {
     @JoinColumn(name = "room_id", nullable = true )  // DB와 동기화
     private Room room;
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Customization customization;
 }

--- a/src/main/resources/static/custom.html
+++ b/src/main/resources/static/custom.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>캐릭터 커스터마이징 테스트</title>
+</head>
+<body>
+<h2>커스터마이징 선택</h2>
+
+<label for="nickname">닉네임:</label>
+<input type="text" id="nickname" placeholder="닉네임을 입력하세요" />
+
+<br><br>
+
+<label for="hair">머리 스타일:</label>
+<select id="hair">
+  <option value="0">기본</option>
+  <option value="1">짧은 머리</option>
+  <option value="2">긴 머리</option>
+  <option value="3">파마</option>
+  <option value="4">포니테일</option>
+  <option value="5">스포츠컷</option>
+</select>
+
+<br><br>
+
+<label for="outfit">옷 스타일:</label>
+<select id="outfit">
+  <option value="0">기본 옷</option>
+  <option value="1">청바지</option>
+  <option value="2">슈트</option>
+  <option value="3">운동복</option>
+  <option value="4">드레스</option>
+  <option value="5">후드티</option>
+</select>
+
+<br><br>
+<button onclick="submitCustomization()">저장</button>
+
+<h3>브로드캐스트 수신 로그</h3>
+<pre id="broadcastLog" style="background:#f4f4f4; padding:10px;"></pre>
+
+<script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+
+<script>
+  // === WebSocket 연결 및 구독 ===
+  const socket = new SockJS('http://localhost:8080/ws/app'); // 서버 주소에 맞게 수정
+  const stompClient = Stomp.over(socket);
+
+  stompClient.connect({}, function () {
+    console.log("WebSocket 연결됨");
+    stompClient.subscribe('/topic/customization', function (message) {
+      const data = JSON.parse(message.body);
+      const log = `📣 브로드캐스트 수신됨!
+유저 ID: ${data.userId}
+머리 타입: ${data.hairType}
+옷 타입: ${data.outfitType}
+==============================`;
+      document.getElementById("broadcastLog").innerText += log + '\n';
+    });
+  });
+
+  // === REST API 호출 ===
+  function submitCustomization() {
+    const nickname = document.getElementById("nickname").value;
+    const hairType = document.getElementById("hair").value;
+    const outfitType = document.getElementById("outfit").value;
+
+    if (!nickname) {
+      alert("닉네임을 입력하세요.");
+      return;
+    }
+
+    fetch("http://localhost:8080/api/customization/update", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        nickname: nickname,
+        hairType: parseInt(hairType),
+        outfitType: parseInt(outfitType)
+      })
+    })
+    .then(response => {
+      if (response.ok) {
+        alert("저장 요청 성공 (브로드캐스트는 로그로 확인)");
+      } else {
+        alert("저장 요청 실패");
+      }
+    });
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#37 

### 📝 작업 내용
프론트에서 주는 에셋 정보를 db에 저장하고 전송할 수 있게 해줍니다.
프론트에서 유저닉네임만 주면 id를 찾아 알아서 저장합니다.
html 파일로 테스트 가능합니다.

### 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e5add609-82ca-4847-8be6-a6029d26000d)
![image](https://github.com/user-attachments/assets/f43820a3-fcd8-481f-a56c-0cabd05d245c)


### 💬 리뷰 요구사항 (선택)

