### PR TITLE
GitHub Actions scp, ssh 액션에 안정적인 버전 명시

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,7 +67,7 @@ jobs:
           cat .env
 
       - name: Copy .env and compose files to EC2
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
@@ -77,7 +77,7 @@ jobs:
 
       # 8) EC2에서 Docker Compose 실행 및 배포
       - name: Deploy to EC2 and start containers
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#53 

### 📝 작업 내용
워크플로우 외부 액션(scp, ssh) 버전을 master에서 안정적인 버전 명시로 바꾸어 안정적으로 배포를 진행하려고 합니다.

### 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a3753712-58b3-4c18-8e99-680a3fc16d45)

### 💬 리뷰 요구사항 (선택)

