### PR TITLE
도커 환경에서 프로필 분리 적용 및 .env 환경변수 연동 설정

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -16,13 +16,17 @@ services:
     ports:
       - "8080:8080"
     environment:
-      # --- RDS 관련 ---
       RDS_URL: ${RDS_URL}
       RDS_USERNAME: ${RDS_USERNAME}
       RDS_PASSWORD: ${RDS_PASSWORD}
-      # --- Redis 관련 ---
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       REDIS_CONTAINER_NAME: ${REDIS_CONTAINER_NAME}
+      CLOVA_URL: ${CLOVA_URL}
+      CLOVA_TASK_ID: ${CLOVA_TASK_ID}
+      CLOVA_KEY: ${CLOVA_KEY}
+      CLOVA_PLAYGROUND_KEY: ${CLOVA_PLAYGROUND_KEY}
+      PERPLEXITY_KEY: ${PERPLEXITY_KEY}
+      SPRING_PROFILES_ACTIVE: dev # 개발 환경 프로필 활성화
 
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]

--- a/src/main/java/com/chatting/capstone/global/config/WebSocketConfig.java
+++ b/src/main/java/com/chatting/capstone/global/config/WebSocketConfig.java
@@ -25,7 +25,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/app")
-            .setAllowedOriginPatterns(
+            .setAllowedOrigins(
                     "http://localhost:63342",
                     "https://kuriverse.com") // CORS 허용 부분 정확히 지정
             .withSockJS(); // SockJS fallback 지원

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,38 @@
+spring:
+  jackson:
+    time-zone: Asia/Seoul
+
+  datasource:
+    url: ${RDS_URL}
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+
+  data:
+    redis:
+      host: redis  # Docker 내부 Redis
+      port: 6379
+      password: ${REDIS_PASSWORD}
+
+  sql:
+    init:
+      mode: never
+
+api:
+  clova:
+    base-url: ${CLOVA_URL}
+    task-id: ${CLOVA_TASK_ID}
+    key: ${CLOVA_KEY}
+    ai_key: ${CLOVA_PLAYGROUND_KEY}
+  perplexity:
+    url: https://api.perplexity.ai
+    key: ${PERPLEXITY_KEY}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,33 @@
+spring:
+  jackson:
+    time-zone: Asia/Seoul
+  datasource: # AWS RDS
+    url: ${RDS_URL} # 로컬에서는 ssh 터널링 등으로 접근
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create # 개발 편의를 위해 create 사용
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+  data:
+    redis:
+      host: localhost  # 로컬 Redis 사용 시
+      port: 6379 # Docker에서 Redis 컨테이너가 6379 포트를 사용하므로, 호스트에서도 동일한 포트를 사용
+      # password: ${REDIS_PASSWORD} 로컬 Redis 비밀번호 설정 (필요시)
+  sql:
+    init:
+      mode: never
+api:
+  clova:
+    base-url: ${CLOVA_URL}
+    task-id: ${CLOVA_TASK_ID}
+    key: ${CLOVA_KEY}
+    ai_key: ${CLOVA_PLAYGROUND_KEY}
+  perplexity:
+    url: https://api.perplexity.ai
+    key: ${PERPLEXITY_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,33 +1,3 @@
 spring:
-  jackson:
-    time-zone: Asia/Seoul
-  datasource: # AWS RDS
-    url: ${RDS_URL}
-    username: ${RDS_USERNAME}
-    password: ${RDS_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  jpa:
-    show-sql: true
-    hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
-        format_sql: true
-  data:
-    redis:
-      host: redis #Local: localhost, Docker: redis
-      port: 6379 # Docker에서 Redis 컨테이너가 6379 포트를 사용하므로, 호스트에서도 동일한 포트를 사용
-      password: ${REDIS_PASSWORD}
-  sql:
-    init:
-      mode: never
-api:
-  clova:
-    base-url: ${CLOVA_URL}
-    task-id: ${CLOVA_TASK_ID}
-    key: ${CLOVA_KEY}
-    ai_key: ${CLOVA_PLAYGROUND_KEY}
-  perplexity:
-    url: https://api.perplexity.ai
-    key: ${PERPLEXITY_KEY}
+  profiles:
+    active: local # 로컬에서 기본 실행 프로필


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#60 

### 📝 작업 내용
- application-local.yml 로컬 프로필 설정 분리
- 기존 application.yml은 profile=local로 설정 (필요 시 IntelliJ profile=dev로 변경해도 됨)
- docker-compose-dev.yml에서 profile=dev 참조하도록 설정
- Github Secrets에도 SPRING_PROFILES_ACTIVE=dev 설정

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)
프로필 분리 관련해서 모르는 부분 있으면 말씀해주세요!!
