### PR TITLE
Dockerfile에서 jar 파일 경로 명시적으로 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17-jdk
 
 WORKDIR /app
 
-COPY build/libs/*.jar app.jar
+COPY build/libs/capstone-0.0.1-SNAPSHOT.jar app.jar
 
 EXPOSE 8080
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#60 

### 📝 작업 내용
실행에 필요한 jar가 정확히 복사되도록 명시적으로 작성합니다.

현재 컴파일은 정상적으로 되는데, 올바르지 않은 jar가 배포되어서 RDS가 제대로 실행이 안 된 것 같아요.

로컬에서 jar 만들어보면 이렇게 2개가 만들어지는데, 저희가 필요한 건 plain이 없는 jar입니다.
```
capstone-0.0.1-SNAPSHOT.jar → 용량이 71MB 정도라서 fat jar(실행용 완성본)
capstone-0.0.1-SNAPSHOT-plain.jar → 용량이 92KB 정도로 라이브러리 없이 컴파일만 된 jar
```
여기서 build/libs/*.jar는 둘 다 매칭돼서 plain jar가 먼저 복사될 수도 있어서 app.jar가 plain jar일 가능성이 높아요. 
그래서 실행 시 Portal.class 같은 실제 클래스가 없을 수 있습니다.

일단은 Dockerfile을 다음과 같이 수정해볼게요!

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

