### PR TITLE
feat/#86-customization-all 모든 유저 에셋 불러오기

### DIFF
--- a/src/main/java/com/chatting/capstone/domain/customization/controller/CustomizationController.java
+++ b/src/main/java/com/chatting/capstone/domain/customization/controller/CustomizationController.java
@@ -1,8 +1,12 @@
 package com.chatting.capstone.domain.customization.controller;
 
 import com.chatting.capstone.domain.customization.dto.request.CustomizationRequest;
+import com.chatting.capstone.domain.customization.dto.response.CustomizationResponse;
+import com.chatting.capstone.domain.customization.entity.Customization;
 import com.chatting.capstone.domain.customization.service.CustomizationService;
 import com.chatting.capstone.global.response.ApiResponse;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import com.chatting.capstone.global.response.ResponseStatus;
@@ -23,5 +27,11 @@ public class CustomizationController {
         return ResponseEntity
                 .status(ResponseStatus.CUSTOMIZATION_UPDATE_SUCCESS.getStatus())
                 .body(ApiResponse.of(ResponseStatus.CUSTOMIZATION_UPDATE_SUCCESS));
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<CustomizationResponse>> getAllCustomizations() {
+        List<CustomizationResponse> responses = customizationService.getAllCustomizations();
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/chatting/capstone/domain/customization/service/CustomizationService.java
+++ b/src/main/java/com/chatting/capstone/domain/customization/service/CustomizationService.java
@@ -6,6 +6,8 @@ import com.chatting.capstone.domain.customization.entity.Customization;
 import com.chatting.capstone.domain.customization.repository.CustomizationRepository;
 import com.chatting.capstone.domain.user.entity.User;
 import com.chatting.capstone.domain.user.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -43,4 +45,12 @@ public class CustomizationService {
         System.out.println("Broadcasting customization update: " + response);
         messagingTemplate.convertAndSend("/topic/customization", response);
     }
+    public List<CustomizationResponse> getAllCustomizations() {
+        List<Customization> customizations = customizationRepository.findAll();
+
+        return customizations.stream()
+            .map(c -> new CustomizationResponse(c.getNickname(), c.getBodyType()))
+            .collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#86

### 📝 작업 내용
접속한 모든 유저들의 에셋 정보를 불러옵니다.
추후에 방별로 하는 로직으로 개선 예정입니다.

### 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a955ded5-dfda-4a37-ac0f-a4a355fdb648)
![image](https://github.com/user-attachments/assets/340d6908-5045-49e0-8e21-b602b6f466d6)


### 💬 리뷰 요구사항 (선택)

