### PR TITLE
스웨거 관련 시큐리티 경로 추가

### DIFF
--- a/src/main/java/com/chatting/capstone/global/config/SecurityConfig.java
+++ b/src/main/java/com/chatting/capstone/global/config/SecurityConfig.java
@@ -29,7 +29,13 @@ public class SecurityConfig implements WebMvcConfigurer {
                 // 3. 경로별 접근 권한 설정
                 .authorizeHttpRequests(authz -> authz
                         // 웹소켓/SockJS 연결 관련 경로는 모두 허용
-                        .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers(
+                                "/ws/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/swagger-resources/**"
+                        ).permitAll()
                         .anyRequest().permitAll()
                 );
         return http.build();


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#100 

### 📝 작업 내용
도메인 주소로 스웨거 접속 시, CORS가 뜨기 때문에 시큐리티 허용 경로를 추가합니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

