### PR TITLE
캐릭터가 화면 밖 좌표로 이동하는 현상 수정

### DIFF
--- a/src/main/java/com/chatting/capstone/domain/location/controller/MovementController.java
+++ b/src/main/java/com/chatting/capstone/domain/location/controller/MovementController.java
@@ -64,7 +64,7 @@ public class MovementController {
             x = 50;
             y = 40;
         } else {
-            // 방향 이동 처리
+            // 방향 이동 처리(0,0) ~ (1600,900)
             switch (message.getDirection()) {
                 case "w": y = Math.max(0, y - 1); break;
                 case "a": x = Math.max(0, x - 1); break;

--- a/src/main/java/com/chatting/capstone/domain/location/controller/MovementController.java
+++ b/src/main/java/com/chatting/capstone/domain/location/controller/MovementController.java
@@ -66,10 +66,10 @@ public class MovementController {
         } else {
             // 방향 이동 처리
             switch (message.getDirection()) {
-                case "w": y = Math.max(-800, y - 1); break;
-                case "a": x = Math.max(-450, x - 1); break;
-                case "s": y = Math.min(800, y + 1); break;
-                case "d": x = Math.min(450, x + 1); break;
+                case "w": y = Math.max(0, y - 1); break;
+                case "a": x = Math.max(0, x - 1); break;
+                case "s": y = Math.min(900, y + 1); break;
+                case "d": x = Math.min(1600, x + 1); break;
             }
         }
 
@@ -139,8 +139,8 @@ public class MovementController {
         userRepository.save(user);
 
         // 포탈 이동 시 위치 설정
-        x = "left".equals(message.getPortalDirection()) ? 8 : 1;
-        y = 5;
+        x = "left".equals(message.getPortalDirection()) ? 50 : 1550;
+        y = 450;
 
         // 위치 정보 Redis에 저장 (nickname 기준)
         Map<String, Object> saveValue = new HashMap<>();


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#107 

### 📝 작업 내용
캐릭터 이동 좌표를 화면 해상도 기준 (0, 0) ~ (1600, 900) 범위로 제한하도록 수정
포탈 이동 시 캐릭터 위치를 좌/우측 적절한 위치(x=50 또는 x=1550, y=450)로 초기화하도록 구현

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

