### PR TITLE
도메인 변경에 따른 Swagger 및 CORS 설정 수정

### DIFF
--- a/src/main/java/com/chatting/capstone/global/config/SecurityConfig.java
+++ b/src/main/java/com/chatting/capstone/global/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig implements WebMvcConfigurer {
                 "http://localhost:63342",   // 실제 프론트엔드 Origin
                 "http://localhost:5173",    // 프론트엔드 로컬호스트
                 "http://127.0.0.1:5500",    // 프론트엔드 로컬호스트
-                "https://kuriverse.com"     // 도메인 주소 추가
+                "https://kuriverse.com",     // 프론트엔드 도메인
+                "https://darling-starlight-f4b806.netlify.app" // 프론트엔드 netlify 도메인
         ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));

--- a/src/main/java/com/chatting/capstone/global/config/SwaggerConfig.java
+++ b/src/main/java/com/chatting/capstone/global/config/SwaggerConfig.java
@@ -27,7 +27,7 @@ public class SwaggerConfig {
         SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
         return new OpenAPI()
-            .servers(List.of(new Server().url("https://kuriverse.com")))
+            .servers(List.of(new Server().url("https://kuriverse.shop")))
             .info(info)
             .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
             .security(Arrays.asList(securityRequirement));

--- a/src/main/java/com/chatting/capstone/global/config/WebSocketConfig.java
+++ b/src/main/java/com/chatting/capstone/global/config/WebSocketConfig.java
@@ -28,7 +28,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             .setAllowedOrigins(
                     "http://localhost:63342",
                     "http://127.0.0.1:5500",    // 프론트엔드 로컬호스트
-                    "https://kuriverse.com") // CORS 허용 부분 정확히 지정
+                    "https://kuriverse.com", // 프론트엔드 도메인
+                    "https://darling-starlight-f4b806.netlify.app") // 프론트엔드 netlify 도메인
             .withSockJS(); // SockJS fallback 지원
     }
 }

--- a/src/main/resources/static/front/BridgeScene.js
+++ b/src/main/resources/static/front/BridgeScene.js
@@ -1,6 +1,6 @@
 import { stompClient } from './game.js';
 
-const SERVER_URL = 'https://kuriverse.com';
+const SERVER_URL = 'https://kuriverse.shop';
 
 class BridgeScene extends Phaser.Scene {
   constructor() {

--- a/src/main/resources/static/front/CharacterSelectScene.js
+++ b/src/main/resources/static/front/CharacterSelectScene.js
@@ -1,4 +1,4 @@
-const SERVER_URL = 'https://kuriverse.com'; 
+const SERVER_URL = 'https://kuriverse.shop';
 
 class CharacterSelectScene extends Phaser.Scene {
   constructor() {

--- a/src/main/resources/static/front/index.html
+++ b/src/main/resources/static/front/index.html
@@ -22,12 +22,12 @@
   </style>
 
   <script>
-    const SERVER_URL = "https://kuriverse.com";
-    const WS_URL = "https://kuriverse.com/ws/app";
+    const SERVER_URL = "https://kuriverse.shop";
+    const WS_URL = "https://kuriverse.shop/ws/app";
   </script>
 </head>
 <body>
-  <div id="game-container"></div> 
+  <div id="game-container"></div>
   <script type="module" src="game.js"></script>
 </body>
 </html>

--- a/src/main/resources/static/front/mainScene.js
+++ b/src/main/resources/static/front/mainScene.js
@@ -1,6 +1,6 @@
 import { stompClient } from './game.js';
 
-const SERVER_URL = 'https://kuriverse.com';
+const SERVER_URL = 'https://kuriverse.shop';
 
 class MainScene extends Phaser.Scene {
   constructor() {


### PR DESCRIPTION
### #️⃣ 연관된 이슈
#111 

### 📝 작업 내용
- 연동 편의를 위해서 프론트엔드가 배포되어있는 netlify 도메인 추가했습니다. 추후 .com으로 변경해야 합니다.
- 스웨거 서버 도메인 변경했습니다.
- 일단 서버의 static 정적 파일의 서버 주소는 변경했는데, 프론트엔드에서도 서버 주소 관련 코드 변경이 필요합니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

